### PR TITLE
bin: update console message

### DIFF
--- a/bin/linklocal.js
+++ b/bin/linklocal.js
@@ -43,7 +43,7 @@ if (recursive) fn = fn.recursive
 fn(dir, pkg, function(err, items) {
   if (err) throw err
   var commandName = command[0].toUpperCase() + command.slice(1)
-  console.error('%sed %d dependencies', commandName, items.length)
+  console.error('%sed %d dependenc' + (1 == items.length ? 'y' : 'ies'), commandName, items.length)
   items.forEach(function(item) {
     console.info('%sed %s', commandName, path.relative(process.cwd(), item))
   })


### PR DESCRIPTION
This sets the `linked dependencies` message to be singular in case only one dependency is linked. Hopefully this is helpful. Thanks!

![screen shot 2014-09-30 at 14 28 54](https://cloud.githubusercontent.com/assets/2467194/4457943/c9d04838-489d-11e4-89fc-952712a0c097.png)
