### PR TITLE
Absolute junctions for Windows XP

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,7 +293,7 @@ function linkLinks(links, done) {
       var from = link.from
       var to = link.to
       
-      // Junctions don't support dangling symlinks
+      // Junction points can't be relative
       if (symlinkType!=='junction') {
         to = path.relative(path.dirname(from), to)
       }


### PR DESCRIPTION
Changes:
- Vista and later support symlinks, only XP needs the "junction" type
- A junction path must be absolute, as explained in #10 (and reported in joyent/node#8813)

Tests now pass on Windows XP (don't ask why I'm using XP).
