### PR TITLE
deps: pin commander to 2.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "tape": "^3.4.0"
   },
   "dependencies": {
-    "commander": "^2.6.0",
+    "commander": "~2.6.0",
     "debug": "~2.1.0",
     "map-limit": "0.0.1",
     "mkdirp": "~0.5.0",


### PR DESCRIPTION
Apparently `commander@2.7` contained breaking changes (updated 19 hours ago). The `linklocal list` / `linklocal link` commands are interpreted as file paths causing errors to be thrown:
```txt
❯ linklocal list
/Users/yoshuawuyts/.nvm/versions/io.js/v1.3.0/lib/node_modules/linklocal/bin/linklocal.js:73
  if (err) throw err
                 ^
Error: ENOENT: no such file or directory, open '/Users/yoshuawuyts/dev/wercker/wercker/src/list/package.json'
    at Error (native)
```
Thanks!
## Changes
- deps: pin `commander` to `~2.6.x`