### PR TITLE
docs: make example portable

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -184,7 +184,7 @@ Linked 3 dependencies
   "name": "my-app",
   "scripts": {
     "dev": "linklocal link -r && linklocal list -r | bulk -c 'npm install --production'",
-    "prepublish": "if [[ $NODE_ENV != 'production' ]]; then npm run dev; fi"
+    "prepublish": "if [ \"$NODE_ENV\" != \"production\" ]; then npm run dev; fi"
   }
 }
 ```


### PR DESCRIPTION
## Changes
- __docs__: The original example relied on bash which isn't as portable as pure
shell. The example was failing on CircleCI; this code should work in all
unix environments.