### PR TITLE
Always use Junctions on Windows (fixes #22)

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,13 +9,9 @@ var assert = require('assert')
 var map = require('map-limit')
 var os = require('os')
 
-// Use junctions on Windows < Vista (6.0),
-// Vista and later support regular symlinks.
-if (os.platform()=='win32' && parseInt(os.release())<6) {
-  var symlinkType = 'junction'
-} else {
-  symlinkType = 'dir'
-}
+// Always use "junctions" on Windows. Even though support for "symbolic links" was added in Vista+, users by default
+// lack permission to create them and administrators need elevation / UAC disabled if using "symbolic links"
+var symlinkType = (os.platform() === 'win32') ? 'junction' : 'dir'
 
 module.exports = function linklocal(dirpath, _done) {
   function done(err, items) {


### PR DESCRIPTION
Windows supports two different types of "soft links", whereas in most MacOS/Linux-based operating systems, the common practice is to use symbolic links. LinkLocal was already using 'junction' links on Windows for versions older than Vista (e.g. XP). However, using a link type of 'symbolic link' on Windows for higher versions throws an error if you are using default Windows settings and are running as a normal user or an administrator that has not elevated into admin mode (e.g. UAC). So this change is of the flavour to just switch to using 'junction' links all the time on Windows, since unelevated/non-admin users are allowed to manage those under default Windows security settings.

Prior to this change, existing LinkLocal tests while on unelevated/non-admin would fail if using default Windows security settings. I verified this change makes it pass for non-admin/unelevated users in the default Windows security config at least on Windows 10 64-bit OS, NTFS file system (default FS type), 64-bit Node v0.12.9, NPM 3.5.2.
