### PR TITLE
Added Linking and Unlinking by Package Name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: required
 dist: trusty
 language: node_js
-before_install: npm install npm -g
 before_script: npm cache clear
+before_install: npm install -g npm@latest
 node_js:
   - "5"
   - "4"

--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,7 @@ linklocal --help
     -r, --recursive        Link recursively
     -q, --unique           Only unique lines of output
     -u, --unlink           Unlink local dependencies
+    --named                Link/Unlink named packages
     --absolute             Format output paths as absolute paths
     --files                Output only symlink targets (--format="%h") [default]
     --links                Output only symlinks (--format="%s")
@@ -42,17 +43,27 @@ linklocal --help
 
   Examples
 
-    $ linklocal                 # link local deps in current dir
-    $ linklocal link            # link local deps in current dir
-    $ linklocal -r              # link local deps recursively
-    $ linklocal unlink          # unlink only in current dir
-    $ linklocal unlink -r       # unlink recursively
+    $ linklocal                                           # link local deps in current dir
+    $ linklocal link                                      # link local deps in current dir
+    $ linklocal -r                                        # link local deps recursively
+    $ linklocal unlink                                    # unlink only in current dir
+    $ linklocal unlink -r                                 # unlink recursively
 
-    $ linklocal list            # list all local deps, ignores link status
-    $ linklocal list -r         # list all local deps recursively, ignoring link status
+    $ linklocal list                                      # list all local deps, ignores link status
+    $ linklocal list -r                                   # list all local deps recursively, ignoring link status
 
-    $ linklocal -- mydir        # link local deps in mydir
-    $ linklocal unlink -- mydir # unlink local deps in mydir
+    $ linklocal -- mydir                                  # link local deps in mydir
+    $ linklocal unlink -- mydir                           # unlink local deps in mydir
+
+    $ linklocal list                                      # list all local deps, ignores link status   
+    $ linklocal list -r                                   # list all local deps recursively, ignoring link status    
+
+    $ linklocal --named pkgname ../to/pkg                 # link local dep by name/path
+    $ linklocal --named pkgname1 pkgname2 ../to/pkg       # link local deps by name/path
+    $ linklocal unlink --named pkgname ../to/pkg          # unlink local dep by name/
+    $ linklocal --named  -r pkgname ../to/pkg             # link local deps recursively by name/
+
+
 
   Formats
 
@@ -175,6 +186,19 @@ node_modules/@nuts/almond -> ../almond
 
 Linked 3 dependencies
 ```
+
+#### Linking and Unlinking Packages by Name
+
+```
+# from test/named
+> linklocal --named mypackagename ../
+node_modules/mypackagename -> ../mypackagename
+
+Linked 1 dependency
+```
+
+When linking local named packages, you may do so regularly or with recursion. The package names should be entered as an unordered list of strings, where the final argument is the relative path to where the source files for these packages are located.
+
 
 ## Recommendations
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ if (os.platform()=='win32' && parseInt(os.release())<6) {
 }
 
 module.exports = function linklocal(dirpath, _done) {
+
   function done(err, items) {
     _done(err, items || [])
   }
@@ -44,6 +45,30 @@ module.exports = function linklocal(dirpath, _done) {
 }
 
 module.exports.link = module.exports
+
+module.exports.link.named = function(dirpath, done, options) {
+  assert.equal(typeof dirpath, 'string', 'dirpath should be a string')
+  assert.equal(typeof done, 'function', 'done should be a function')
+
+  var getLinksFn = options.recursive ? getLinksRecursive : getLinks
+
+  readPackage(dirpath, function(err, pkg) {
+    if (err) return done(err)
+    getLinksFn(pkg, function(err, links) {
+      if (err) return done(err)
+      filterAllLinksToUnlink(links, function(err, toUnlink) {
+        if (err) return done(err)
+        unlinkLinks(toUnlink, function(err) {
+          if (err) return done(err)
+          linkLinks(links, function(err) {
+            if (err) return done(err)
+            done(null, links)
+          })
+        })
+      })
+    }, options);
+  });
+}
 
 module.exports.link.recursive = function linklocalRecursive(dirpath, done) {
   assert.equal(typeof dirpath, 'string', 'dirpath should be a string')
@@ -83,6 +108,25 @@ module.exports.unlink = function unlinklocal(dirpath, done) {
   })
 }
 
+module.exports.unlink.named = function(dirpath, done, options) {
+
+  var getLinksFn = options.recursive ? getLinksRecursive : getLinks
+
+  readPackage(dirpath, function(err, pkg) {
+    if (err) return done(err)
+    getLinksFn(pkg, function(err, links) {
+      if (err) return done(err)
+      filterLinksToUnlink(links, function(err, toUnlink) {
+        if (err) return done(err)
+        unlinkLinks(toUnlink, function(err) {
+          if (err) return done(err)
+          done(null, toUnlink)
+        })
+      })
+    }, options)
+  })
+}
+
 module.exports.unlink.recursive = function unlinklocalRecursive(dirpath, done) {
   assert.equal(typeof dirpath, 'string', 'dirpath should be a string')
   assert.equal(typeof done, 'function', 'done should be a function')
@@ -116,7 +160,7 @@ module.exports.list.recursive = function listRecursive(dirpath, done){
   })
 }
 
-function getLinksRecursive(pkg, done) {
+function getLinksRecursive(pkg, done, options) {
   var _cache = _cache || {}
 
   return (function _getLinksRecursive(pkg, done) {
@@ -131,7 +175,7 @@ function getLinksRecursive(pkg, done) {
           _getLinksRecursive(pkg, next)
         })
       }, done)
-    })
+    }, options)
   })(pkg, function(err) {
     if (err) return done(err)
     var result = Object.keys(_cache).reduce(function(result, key) {
@@ -142,7 +186,7 @@ function getLinksRecursive(pkg, done) {
   })
 }
 
-function getLocalDependenciesRecursive(pkg, done) {
+function getLocalDependenciesRecursive(pkg, done, options) {
   var _cache = _cache || {}
 
   return (function _getLocalDependenciesRecursive(pkg, done) {
@@ -156,7 +200,7 @@ function getLocalDependenciesRecursive(pkg, done) {
           _getLocalDependenciesRecursive(childPkg, next)
         })
       }, done)
-    })
+    }, options)
   })(pkg, function(err) {
     if (err) return done(err)
     return done(null, Object.keys(_cache))
@@ -189,24 +233,31 @@ function readPackage(dirpath, done) {
   })
 }
 
-function getLocalDependencies(pkg, done) {
+function getLocalDependencies(pkg, done, options) {
+
   assert.equal(typeof pkg, 'object', 'pkg should be an object')
   var deps = getDependencies(pkg)
-  var localDependencies = getPackageLocalDependencies(pkg)
+  var localDependencies = getPackageLocalDependencies(pkg, options)
   .map(function(name) {
     var pkgPath = deps[name]
     pkgPath = pkgPath.replace(/^file:/g, '')
+
+    if (options && options.packages.length > 0) {
+      return path.resolve(options.cwd, name)
+    }
+
     return path.resolve(pkg.dirpath, pkgPath)
   })
+
   getRealPaths(localDependencies, done)
 }
 
-function getPackageLocalDependencies(pkg) {
+function getPackageLocalDependencies(pkg, options) {
   assert.equal(typeof pkg, 'object', 'pkg should be an object')
   var deps = getDependencies(pkg)
   return Object.keys(deps).filter(function(name) {
     var dep = deps[name]
-    return isLocalDependency(dep)
+    return isLocalDependency(dep, name, options)
   })
 }
 
@@ -219,8 +270,13 @@ function getDependencies(pkg) {
   return deps
 }
 
-function isLocalDependency(val) {
+function isLocalDependency(val, name, options) {
   var ignoreExt = ".tgz"
+  
+  if (options && options.packages) {
+    return options.packages.indexOf(name) !== -1
+  }
+  
   return (
     (val.indexOf('.') === 0 ||
      val.indexOf('/') === 0 ||
@@ -229,7 +285,7 @@ function isLocalDependency(val) {
   )
 }
 
-function getLinks(pkg, done) {
+function getLinks(pkg, done, options) {
   getLocalDependencies(pkg, function(err, localDependencies) {
     if (err) return done(err)
     var destination = path.join(pkg.dirpath, 'node_modules')
@@ -243,7 +299,7 @@ function getLinks(pkg, done) {
       })
       done(null, links)
     })
-  })
+  }, options)
 }
 
 function isSymbolicLink(filepath, done) {

--- a/test/banana/package.json
+++ b/test/banana/package.json
@@ -1,7 +1,13 @@
 {
   "name": "banana",
   "version": "1.0.0",
-  "private": true,
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Tim Oxley <secoif@gmail.com>",
+  "license": "MIT",
   "dependencies": {
     "apple": "file:../apple"
   }

--- a/test/named.js
+++ b/test/named.js
@@ -1,0 +1,45 @@
+"use strict"
+
+var test = require('tape')
+
+var fs = require("fs")
+var path = require('path')
+var exec = require('child_process').exec
+var rimraf = require('rimraf')
+
+var linklocal = require("../")
+var namedPackagePath = 'test/named';
+
+var PKG_DIR = path.resolve(__dirname, 'named')
+
+test('will link a named package', function(t) {
+  var options = {
+    recursive: false,
+    cwd: path.resolve(process.cwd(), namedPackagePath),
+    packages: ['namedProj1']
+  }
+
+  linklocal.named(PKG_DIR, function(err, linked) { 
+    t.ifError(err)
+    t.ok(linked)
+    t.end()
+  }, options);
+
+})
+
+test('will unlink a named package', function(t) {
+  var options = {
+    recursive: false,
+    cwd: path.resolve(process.cwd(), namedPackagePath),
+    packages: ['namedProj1']
+  }
+
+  linklocal.unlink.named(PKG_DIR, function testLinked(err, linked) {
+    t.ifError(err)
+    linklocal.unlink(PKG_DIR, function testUnlinked(err, unlinked) {
+      t.ok(unlinked)
+      t.end()
+    })
+  }, options)
+
+})

--- a/test/named/namedProject1/package.json
+++ b/test/named/namedProject1/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "namedProject1",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {}
+}

--- a/test/named/package.json
+++ b/test/named/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "named",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "namedProject1": "https://somelocation/to/namedProject1",
+    "banana": "file:../banana",
+    "localPacked": "file:../npmPack-1.0.0.tgz"
+  }
+}


### PR DESCRIPTION
Added Linking and Unlinking by Package Name, associated tests, updated readme.

Rather than explicitly listing a package as a file resource, I wanted to be able to link published or unpublished npm packages locally. Since there was no pattern for matching these kind of dependencies, I decided to allow users to explicitly name packages to link.

`$ linklocal --named my_package_name ../path/to/mypackage`

`$ linklocal --named -r my_package_name my_other_package_name ../path/to/packages`
