### PR TITLE
add scope param to --named action

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ linklocal --help
     -r, --recursive        Link recursively
     -q, --unique           Only unique lines of output
     -u, --unlink           Unlink local dependencies
-    --named                Link/Unlink named packages
+    -n, --named            Link only named packages, last argument is cwd
     --absolute             Format output paths as absolute paths
     --files                Output only symlink targets (--format="%h") [default]
     --links                Output only symlinks (--format="%s")
@@ -43,21 +43,22 @@ linklocal --help
 
   Examples:
 
-    linklocal                                           # link local deps in current dir
-    linklocal link                                      # link local deps in current dir
-    linklocal -r                                        # link local deps recursively
-    linklocal unlink                                    # unlink only in current dir
-    linklocal unlink -r                                 # unlink recursively
+    linklocal                                                 # link local deps in current dir
+    linklocal link                                            # link local deps in current dir
+    linklocal -r                                              # link local deps recursively
+    linklocal unlink                                          # unlink only in current dir
+    linklocal unlink -r                                       # unlink recursively
 
-    linklocal list                                      # list all local deps, ignores link status
-    linklocal list -r                                   # list all local deps recursively, ignoring link status
+    linklocal list                                            # list all local deps, ignores link status
+    linklocal list -r                                         # list all local deps recursively, ignoring link status
 
-    linklocal -- mydir                                  # link local deps in mydir
-    linklocal unlink -- mydir                           # unlink local deps in mydir
-    linklocal --named pkgname ../to/pkg                 # link local dep by name/path
-    linklocal --named pkgname1 pkgname2 ../to/pkg       # link local deps by name/path
-    linklocal unlink --named pkgname ../to/pkg          # unlink local dep by name/
-    linklocal --named  -r pkgname ../to/pkg             # link local deps recursively by name/
+    linklocal -- mydir                                        # link local deps in mydir
+    linklocal unlink -- mydir                                 # unlink local deps in mydir
+    linklocal --named pkgname ../to/pkg                       # link local dep by name/path
+    linklocal --named pkgname1 pkgname2 ../to/pkg             # link local deps by name/path
+    linklocal unlink --named pkgname ../to/pkg                # unlink local dep by name/
+    linklocal --named -r pkgname ../to/pkg                    # link local deps recursively by name/
+    linklocal --named -r @scope/pkgname pkgname ../to/pkg     # link local deps recursively by name/ with npm @scope
 
   Formats:
 

--- a/bin/linklocal.js
+++ b/bin/linklocal.js
@@ -24,21 +24,22 @@ program
 program.on('--help', function () {
   console.info('  Examples:')
   console.info('')
-  console.info('    linklocal                                           # link local deps in current dir')
-  console.info('    linklocal link                                      # link local deps in current dir')
-  console.info('    linklocal -r                                        # link local deps recursively')
-  console.info('    linklocal unlink                                    # unlink only in current dir')
-  console.info('    linklocal unlink -r                                 # unlink recursively')
+  console.info('    linklocal                                                 # link local deps in current dir')
+  console.info('    linklocal link                                            # link local deps in current dir')
+  console.info('    linklocal -r                                              # link local deps recursively')
+  console.info('    linklocal unlink                                          # unlink only in current dir')
+  console.info('    linklocal unlink -r                                       # unlink recursively')
   console.info('')
-  console.info('    linklocal list                                      # list all local deps, ignores link status')
-  console.info('    linklocal list -r                                   # list all local deps recursively, ignoring link status')
+  console.info('    linklocal list                                            # list all local deps, ignores link status')
+  console.info('    linklocal list -r                                         # list all local deps recursively, ignoring link status')
   console.info('')
-  console.info('    linklocal -- mydir                                  # link local deps in mydir')
-  console.info('    linklocal unlink -- mydir                           # unlink local deps in mydir')
-  console.info('    linklocal --named pkgname ../to/pkg                 # link local dep by name/path')
-  console.info('    linklocal --named pkgname1 pkgname2 ../to/pkg       # link local deps by name/path')
-  console.info('    linklocal unlink --named pkgname ../to/pkg          # unlink local dep by name/')
-  console.info('    linklocal --named  -r pkgname ../to/pkg             # link local deps recursively by name/')
+  console.info('    linklocal -- mydir                                        # link local deps in mydir')
+  console.info('    linklocal unlink -- mydir                                 # unlink local deps in mydir')
+  console.info('    linklocal --named pkgname ../to/pkg                       # link local dep by name/path')
+  console.info('    linklocal --named pkgname1 pkgname2 ../to/pkg             # link local deps by name/path')
+  console.info('    linklocal unlink --named pkgname ../to/pkg                # unlink local dep by name/')
+  console.info('    linklocal --named -r pkgname ../to/pkg                    # link local deps recursively by name/')
+  console.info('    linklocal --named -r @scope/pkgname pkgname ../to/pkg     # link local deps recursively by name/ with npm @scope')
   console.info('')
   console.info('  Formats:')
   console.info('')
@@ -81,6 +82,18 @@ var options = !named ? {} : {
   cwd: program.args[program.args.length - 1],
   packages: program.args.slice(0, program.args.length - 1),
   recursive: recursive
+}
+
+if (named) {
+  var renameIndex = program.args.findIndex(function (arg) { return arg.indexOf('@') !== -1 })
+  var rename = renameIndex !== -1 ? program.args[renameIndex + 1] : null
+
+  options = {
+    cwd: program.args[program.args.length - 1],
+    packages: program.args.slice(0, program.args.length - 1),
+    scopeRename: rename,
+    recursive: recursive
+  }
 }
 
 fn(dir, function (err, items) {

--- a/index.js
+++ b/index.js
@@ -216,6 +216,10 @@ function getLocalDependencies (pkg, done, options) {
     var pkgPath = deps[name]
     pkgPath = pkgPath.replace(/^file:/g, '')
 
+    if (options && options.scopeRename) {
+      return path.resolve(options.cwd, options.scopeRename)
+    }
+
     if (options && options.packages.length > 0) {
       return path.resolve(options.cwd, name)
     }
@@ -247,6 +251,10 @@ function getDependencies (pkg) {
 function isLocalDependency (val, name, options) {
   var ignoreExt = '.tgz'
 
+  if (options && options.scopeRename && options.packages) {
+    return isScopedDependency(name, options)
+  }
+
   if (options && options.packages) {
     return options.packages.indexOf(name) !== -1
   }
@@ -275,6 +283,10 @@ function getLinks (pkg, done, options) {
     })
   }, options)
 }
+
+function isScopedDependency (name, options) {
+  return name.indexOf('@') !== -1 && options.packages.indexOf(name) !== -1
+};
 
 function isSymbolicLink (filepath, done) {
   exists(filepath, function (err, doesExist) {

--- a/test/@namespace/thing/package.json
+++ b/test/@namespace/thing/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@namespace/thing",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {}
+}

--- a/test/scoped.js
+++ b/test/scoped.js
@@ -1,0 +1,43 @@
+'use strict'
+
+var test = require('tape')
+
+var path = require('path')
+
+var linklocal = require('../')
+var scopedPackagePath = '@namespace/thing'
+
+var PKG_DIR = path.resolve(__dirname, scopedPackagePath)
+
+test('will link a scoped package', function (t) {
+  var options = {
+    recursive: false,
+    cwd: path.resolve(process.cwd(), scopedPackagePath),
+    scopeRename: 'thing',
+    packages: ['@namespace/thing', 'thing']
+  }
+
+  linklocal.named(PKG_DIR, function (err, linked) {
+    t.ifError(err)
+    t.ok(linked)
+    t.end()
+  }, options)
+})
+
+test('will unlink a scoped package', function (t) {
+  var options = {
+    recursive: false,
+    cwd: path.resolve(process.cwd(), scopedPackagePath),
+    scopeRename: 'thing',
+    packages: ['@namespace/thing', 'thing']
+  }
+
+  linklocal.unlink.named(PKG_DIR, function testLinked (err, linked) {
+    t.ifError(err)
+    linklocal.unlink(PKG_DIR, function testUnlinked (err, unlinked) {
+      t.ifError(err)
+      t.ok(unlinked)
+      t.end()
+    })
+  }, options)
+})


### PR DESCRIPTION
## About

This PR introduces the `-s` or `--scope` option to `linklocal`. Option will be used in `--named` action.
## Purpose

Previously, users of `linklocal` could use the `--named` argument to `link` named packages. However, this only worked with a 1:1 relationship between name and foldername. Generally this is ok, since folder names conventionally match package names with `node_modules`. 

However, when working with `npm scoped` packages, this causes an issue.
## Solution

When calling `linklocal --named @scope/packge_name` you can name declare the symlink as a scoped package. The command would look like:

`npm link --named @scope/package_name --scoped package_name ../`

![image](https://cloud.githubusercontent.com/assets/6272507/16927529/593fee96-4cf3-11e6-9c7d-80622e1abf3e.png)
